### PR TITLE
fix session handler return value in read

### DIFF
--- a/src/Spryker/Shared/Session/Business/Handler/SessionHandlerCouchbase.php
+++ b/src/Spryker/Shared/Session/Business/Handler/SessionHandlerCouchbase.php
@@ -132,7 +132,7 @@ class SessionHandlerCouchbase implements \SessionHandlerInterface
         $result = $this->connection->getAndTouch($key, $this->lifetime);
         $this->newRelicApi->addCustomMetric(self::METRIC_SESSION_READ_TIME, microtime(true) - $startTime);
 
-        return $result ? json_decode($result, true) : null;
+        return $result ? json_decode($result, true) : '';
     }
 
     /**

--- a/src/Spryker/Shared/Session/Business/Handler/SessionHandlerFile.php
+++ b/src/Spryker/Shared/Session/Business/Handler/SessionHandlerFile.php
@@ -90,7 +90,7 @@ class SessionHandlerFile implements \SessionHandlerInterface
 
         $this->newRelicApi->addCustomMetric(self::METRIC_SESSION_READ_TIME, microtime(true) - $startTime);
 
-        return $content;
+        return ($content === false) ? '' : $content;
     }
 
     /**

--- a/src/Spryker/Shared/Session/Business/Handler/SessionHandlerMysql.php
+++ b/src/Spryker/Shared/Session/Business/Handler/SessionHandlerMysql.php
@@ -127,7 +127,7 @@ class SessionHandlerMysql implements \SessionHandlerInterface
         $result = $statement->fetch();
         $this->newRelicApi->addCustomMetric(self::METRIC_SESSION_READ_TIME, microtime(true) - $startTime);
 
-        return $result ? json_decode($result['value'], true) : null;
+        return $result ? json_decode($result['value'], true) : '';
     }
 
     /**

--- a/src/Spryker/Shared/Session/Business/Handler/SessionHandlerRedis.php
+++ b/src/Spryker/Shared/Session/Business/Handler/SessionHandlerRedis.php
@@ -89,7 +89,7 @@ class SessionHandlerRedis implements \SessionHandlerInterface
         $result = $this->connection->get($key);
         $this->newRelicApi->addCustomMetric(self::METRIC_SESSION_READ_TIME, microtime(true) - $startTime);
 
-        return $result ? json_decode($result, true) : null;
+        return $result ? json_decode($result, true) : '';
     }
 
     /**


### PR DESCRIPTION
Session Handler interfaces requires a string as return value.

Like mentioned in the docs: https://secure.php.net/manual/en/sessionhandlerinterface.read.php

>  If the record was not found, return an empty string. 
