### PR TITLE
TE-7948: Backport to make Redis config parameters non-mandatory

### DIFF
--- a/src/Spryker/Zed/Session/SessionConfig.php
+++ b/src/Spryker/Zed/Session/SessionConfig.php
@@ -107,7 +107,7 @@ class SessionConfig extends AbstractBundleConfig
      */
     public function getSessionHandlerRedisDataSourceNameZed()
     {
-        if (!$this->getIsRedisSessionHandler($this->getConfiguredSessionHandlerNameZed())) {
+        if (!$this->isRedisSessionHandler($this->getConfiguredSessionHandlerNameZed())) {
             return '';
         }
 
@@ -125,14 +125,15 @@ class SessionConfig extends AbstractBundleConfig
      *
      * @return bool
      */
-    protected function getIsRedisSessionHandler(string $configuredSessionHandlerName): bool
+    protected function isRedisSessionHandler(string $configuredSessionHandlerName): bool
     {
         return in_array(
             $configuredSessionHandlerName,
             [
                 SessionConstants::SESSION_HANDLER_REDIS,
                 SessionConstants::SESSION_HANDLER_REDIS_LOCKING,
-            ]
+            ],
+            true
         );
     }
 
@@ -193,7 +194,7 @@ class SessionConfig extends AbstractBundleConfig
      */
     public function getSessionHandlerRedisDataSourceNameYves()
     {
-        if (!$this->getIsRedisSessionHandler($this->getConfiguredSessionHandlerNameYves())) {
+        if (!$this->isRedisSessionHandler($this->getConfiguredSessionHandlerNameYves())) {
             return '';
         }
 

--- a/src/Spryker/Zed/Session/SessionConfig.php
+++ b/src/Spryker/Zed/Session/SessionConfig.php
@@ -107,12 +107,32 @@ class SessionConfig extends AbstractBundleConfig
      */
     public function getSessionHandlerRedisDataSourceNameZed()
     {
+        if (!$this->getIsRedisSessionHandler($this->getConfiguredSessionHandlerNameZed())) {
+            return '';
+        }
+
         return $this->buildDataSourceName(
-            $this->get(SessionConstants::ZED_SESSION_REDIS_PROTOCOL),
-            $this->get(SessionConstants::ZED_SESSION_REDIS_HOST),
-            $this->get(SessionConstants::ZED_SESSION_REDIS_PORT),
+            $this->get(SessionConstants::ZED_SESSION_REDIS_PROTOCOL, ''),
+            $this->get(SessionConstants::ZED_SESSION_REDIS_HOST, ''),
+            $this->get(SessionConstants::ZED_SESSION_REDIS_PORT, ''),
             $this->get(SessionConstants::ZED_SESSION_REDIS_DATABASE, static::DEFAULT_REDIS_DATABASE),
             $this->get(SessionConstants::ZED_SESSION_REDIS_PASSWORD, false)
+        );
+    }
+
+    /**
+     * @param string $configuredSessionHandlerName
+     *
+     * @return bool
+     */
+    protected function getIsRedisSessionHandler(string $configuredSessionHandlerName): bool
+    {
+        return in_array(
+            $configuredSessionHandlerName,
+            [
+                SessionConstants::SESSION_HANDLER_REDIS,
+                SessionConstants::SESSION_HANDLER_REDIS_LOCKING,
+            ]
         );
     }
 
@@ -173,10 +193,14 @@ class SessionConfig extends AbstractBundleConfig
      */
     public function getSessionHandlerRedisDataSourceNameYves()
     {
+        if (!$this->getIsRedisSessionHandler($this->getConfiguredSessionHandlerNameYves())) {
+            return '';
+        }
+
         return $this->buildDataSourceName(
-            $this->get(SessionConstants::YVES_SESSION_REDIS_PROTOCOL),
-            $this->get(SessionConstants::YVES_SESSION_REDIS_HOST),
-            $this->get(SessionConstants::YVES_SESSION_REDIS_PORT),
+            $this->get(SessionConstants::YVES_SESSION_REDIS_PROTOCOL, ''),
+            $this->get(SessionConstants::YVES_SESSION_REDIS_HOST, ''),
+            $this->get(SessionConstants::YVES_SESSION_REDIS_PORT, ''),
             $this->get(SessionConstants::YVES_SESSION_REDIS_DATABASE, static::DEFAULT_REDIS_DATABASE),
             $this->get(SessionConstants::YVES_SESSION_REDIS_PASSWORD, false)
         );


### PR DESCRIPTION
- Developer(s): @bezpiatovs

- Ticket: https://spryker.atlassian.net/browse/TE-7948

- Academy PR: ACADEMY_URL_HERE

- PR Overview: https://release.spryker.com/release/hotfix?type=patch&pr=https%3A%2F%2Fgithub.com%2Fspryker%2Fsession%2Fpull%2F2

#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   Session               | patch                 |                       |

-----------------------------------------

#### Module Session

##### Change log

Fixes

- Backported session configuration parameters validation in `SessionConfig`, so that Redis-related parameters are mandatory only for Redis-related handlers.
